### PR TITLE
Bump glassfish-copyright-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.3</version>
                     <configuration>
                         <scm>git</scm>
                         <scmOnly>true</scmOnly>


### PR DESCRIPTION
With currently set up one `mvn install` results in:
```
[ERROR] Failed to execute goal org.glassfish.copyright:glassfish-copyright-maven-plugin:2.0:copyright (default) on project glassfishbuild-maven-plugin: Unable to parse configuration of mojo org.glassfish.copyright:glassfish-copyright-maven-plugin:2.0:copyright for parameter resources: Cannot assign configuration entry 'resources' with value 'null' of type org.apache.maven.model.merge.ModelMerger.MergingList to property of type java.util.ArrayList -> [Help 1]
```

Note: Build works fine with maven up to 3.6.1, and fails with above since maven 3.6.2.

Reference: https://github.com/eclipse-ee4j/glassfish-copyright-plugin/issues/7