### PR TITLE
Update glassfish-copyright-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.4</version>
                     <configuration>
                         <scm>git</scm>
                         <scmOnly>true</scmOnly>
@@ -179,10 +179,12 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>copyright</goal>
                             <goal>check</goal>
                         </goals>
                         <phase>verify</phase>
+                        <configuration>
+                            <quiet>false</quiet>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
With new version of plugin, there is no need for separate `copyright` goal to run, as check can report violations now too.