### PR TITLE
Bump target/source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
`System.lineSeparator()` used in `MergeCopyrightHeadersMojo` is `@since 1.7`.