### PR TITLE
Update maven-model-builder scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model-builder</artifactId>
             <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
Reduce
```
The following dependencies are in wrong scope:
 * org.apache.maven:maven-model:jar:3.8.5:compile
 * org.apache.maven:maven-builder-support:jar:3.8.5:compile
 * org.apache.maven:maven-artifact:jar:3.8.5:compile
 * org.apache.maven:maven-plugin-api:jar:3.8.5:compile
 * org.apache.maven:maven-model-builder:jar:3.8.5:compile
```
to
```
The following dependencies are in wrong scope:
 * org.apache.maven:maven-model:jar:3.8.5:compile
 * org.apache.maven:maven-artifact:jar:3.8.5:compile
 * org.apache.maven:maven-plugin-api:jar:3.8.5:compile
```

Fixes - partially only
- #54 

The _reduced_ violations shall be fixed by released MPLUGIN-385 I believe.

I think that the version transits from `maven-core`'s dependencies but the scope is promoted to `compile` by `maven-archiver` and `maven-common-artifact-filters`.