### PR TITLE
Set minimal compatible maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
       <tag>HEAD</tag>
     </scm>
 
+    <prerequisites>
+        <maven>3.9.0</maven>
+    </prerequisites>
+
     <properties>
         <maven.version>3.9.4</maven.version>
         <release.arguments />


### PR DESCRIPTION
I tried to build GlassFish with other versions of Maven:
* 3.8.4 is incompatible
  ```
    1) Error injecting constructor, java.lang.NoSuchMethodError: 'void org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping.<init>(java.util.List)'
    at org.glassfish.build.GlassFishJarLifecycle.<init>(Unknown Source)
    while locating org.glassfish.build.GlassFishJarLifecycle
    at ClassRealm[extension>org.glassfish.build:glassfishbuild-maven-plugin:4.0.0-M1, parent: jdk.internal.loader.ClassLoaders$AppClassLoader@5ffd2b27] (via modules: org.eclipse.sisu.wire.WireModule -> org.eclipse.sisu.plexus.PlexusBindingModule)
    while locating org.apache.maven.lifecycle.mapping.LifecycleMapping annotated with @com.google.inject.name.Named(value="glassfish-jar")
  ```

* 3.9.0 passed