### PR TITLE
Narrowed and fixed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,34 @@
     </build>
 
     <dependencies>
+        <!-- Used by FeatureSetDependenciesMojo -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>4.9.2</version>
+        </dependency>
+
+        <!-- 4.0.0 is not compatible with Maven 3.9.x -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.1</version>
+        </dependency>
+
+        <!-- Two older conflicting transitive versions -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+
+        <!-- Provided dependencies have lower priority than compile+runtime, affects transitive deps -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
@@ -243,17 +271,6 @@
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.12.0</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-archiver</artifactId>
-            <version>3.6.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-shared-utils</artifactId>
-            <version>3.4.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/glassfish/build/FeatureSetsDependenciesMojo.java
+++ b/src/main/java/org/glassfish/build/FeatureSetsDependenciesMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -35,7 +36,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.utils.StringUtils;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;


### PR DESCRIPTION
- Using StringUtils from commons-lang3 instead of maven-shared-utils
  - commons-lang3 lib was already in transitive deps
- The plexus-archiver is directly referred from FeatureSetDependenciesMojo
- Tested with today both GF master and gf8 branches
- As both Maven and Plexus are moving to the future, they sometimes move classes or remove dependencies. We should respect these changes in the future.