### PR TITLE
Configure maven site build with documentation of plugin goals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
     <version>4.0.2-SNAPSHOT</version>
 
     <name>GlassFishBuild Maven Plugin</name>
+    <description>
+        GlassFish Build Maven Plugin contains goals that help with Eclipse GlassFish build.
+    </description>
     <url>https://github.com/eclipse-ee4j/glassfish-build-maven-plugin</url>
 
     <issueManagement>
@@ -62,10 +65,10 @@
     </licenses>
 
     <scm>
-      <connection>scm:git:git://github.com/eclipse-ee4j/glassfish-build-maven-plugin.git</connection>
-      <developerConnection>scm:git:git://github.com/eclipse-ee4j/glassfish-build-maven-plugin.git</developerConnection>
-      <url>https://github.com/eclipse-ee4j/glassfish-build-maven-plugin</url>
-      <tag>HEAD</tag>
+        <connection>scm:git:git://github.com/eclipse-ee4j/glassfish-build-maven-plugin.git</connection>
+        <developerConnection>scm:git:git://github.com/eclipse-ee4j/glassfish-build-maven-plugin.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/glassfish-build-maven-plugin</url>
+        <tag>HEAD</tag>
     </scm>
 
     <prerequisites>
@@ -167,6 +170,11 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.21.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -289,4 +297,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
+                <version>3.15.1</version>
+            </plugin>
+        </plugins>
+    </reporting>    
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.1.0</version>
+    </skin>
+    <body>
+        <menu name="Overview">
+            <item name="Introduction" href="index.html"/>
+            <item name="Goals" href="plugin-info.html"/>
+        </menu>
+    </body>
+</project>


### PR DESCRIPTION
Once built using `mvn site`, it can be run locally with `mvn site:run` and will look like this:

![image](https://github.com/user-attachments/assets/26ad69f3-9acb-4856-8ae9-0126c14e0c81)
 